### PR TITLE
README: move "npm install" to be with "install dependencies"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 Make sure you have Purescript installed globally, e.g. using NPM:
 ```shell
 npm install -g purescript
-npm install
 ```
 
 Install dependencies
 ```shell
+npm install
 npm run deps
 ```
 


### PR DESCRIPTION
 Move `npm install` to be with `npm run deps` since it's part of the installation of dependencies rather than installing purescript. (Minor point, but I was a bit confused...)